### PR TITLE
adding required package color

### DIFF
--- a/template/FITthesisXE.cls
+++ b/template/FITthesisXE.cls
@@ -68,6 +68,7 @@
 \RequirePackage {minted}		% source code highlighting via Pygments
 \RequirePackage {etoolbox}
 \RequirePackage {nameref}
+\RequirePackage	{color}
 
 % microtype currently supports only protrusion with XeLaTeX :(
 \RequirePackage [protrusion=true] {microtype}


### PR DESCRIPTION
When i tried to use this template, i have got an error:
```
! Undefined control sequence.
\set@color ->\special {color push \current@color 
                                                 }\aftergroup \reset@color 
l.34 \begin{document}
                     
? 
! Emergency stop.
\set@color ->\special {color push \current@color 
                                                 }\aftergroup \reset@color 
l.34 \begin{document}
                     
End of file on the terminal!
```
Adding package color solved the issue.